### PR TITLE
Support for posting new WRs in a dedicated channel

### DIFF
--- a/config.example.js
+++ b/config.example.js
@@ -2,6 +2,7 @@ module.exports = {
   "discord-response-channel-id": '123456789123456789',
   "discord-notifications-channel-id": '123456789123456789',
   "discord-colors-channel-id": '123456789123456789',
+  "discord-wr-channel-id": '123456789123456789',
   "target-game-id": '110758',
   "bot-user-name": 'Bot',
   "bot-avatar-url": 'https://cdn.discordapp.com/avatars/574179086591590420/42331bf5233c7c7203a8e7d794199191.png',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,26 +2,116 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "ajv": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        }
+      }
+    },
+    "bluebird": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg=="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "discord.js": {
       "version": "11.3.2",
       "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-11.3.2.tgz",
       "integrity": "sha512-Abw9CTMX3Jb47IeRffqx2VNSnXl/OsTdQzhvbw/JnqCyqc2imAocc7pX2HoRmgKd8CgSqsjBFBneusz/E16e6A==",
       "requires": {
-        "long": "4.0.0",
-        "prism-media": "0.0.2",
-        "snekfetch": "3.6.4",
-        "tweetnacl": "1.0.0",
-        "ws": "4.1.0"
+        "long": "^4.0.0",
+        "prism-media": "^0.0.2",
+        "snekfetch": "^3.6.4",
+        "tweetnacl": "^1.0.0",
+        "ws": "^4.0.0"
       },
       "dependencies": {
         "ws": {
@@ -29,10 +119,86 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
           "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
           "requires": {
-            "async-limiter": "1.0.0",
-            "safe-buffer": "5.1.1"
+            "async-limiter": "~1.0.0",
+            "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -40,20 +206,99 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
       "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
     "long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "requires": {
+        "mime-db": "1.40.0"
+      }
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+    },
     "prism-media": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-0.0.2.tgz",
       "integrity": "sha512-L6yc8P5NVG35ivzvfI7bcTYzqFV+K8gTfX9YaJbmIFfMXTs71RMnAupvTQPTCteGsiOy9QcNLkQyWjAafY/hCQ=="
+    },
+    "psl": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "1.2.0",
@@ -65,9 +310,67 @@
       "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "requires": {
-        "decode-uri-component": "0.2.0",
-        "object-assign": "4.1.1",
-        "strict-uri-encode": "1.1.0"
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+        }
+      }
+    },
+    "request-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
+      "integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "request-promise-core": "1.1.3",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+      "integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
+      "requires": {
+        "lodash": "^4.17.15"
       }
     },
     "restler": {
@@ -86,6 +389,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "sax": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
@@ -96,10 +404,62 @@
       "resolved": "https://registry.npmjs.org/snekfetch/-/snekfetch-3.6.4.tgz",
       "integrity": "sha512-NjxjITIj04Ffqid5lqr7XdgwM7X61c/Dns073Ly170bPQHLm6jkmelye/eglS++1nfTWktpP6Y2bFXjdPlQqdw=="
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "dependencies": {
+        "tweetnacl": {
+          "version": "0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+        }
+      }
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+    },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "tweetnacl": {
       "version": "1.0.0",
@@ -111,8 +471,31 @@
       "resolved": "https://registry.npmjs.org/twitch-helix-api/-/twitch-helix-api-1.0.1.tgz",
       "integrity": "sha512-8NOUoqUultQxeHM5R4NcWtAl7FcIsntzeZLePfBj+I1sEVdW+hLKzjCFr5CUZOix/+L0PrZOnOeJlCya8W6KEA==",
       "requires": {
-        "query-string": "5.1.1",
-        "restler": "3.4.0"
+        "query-string": "^5.0.1",
+        "restler": "^3.4.0"
+      }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "xml2js": {
@@ -120,8 +503,8 @@
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.0.tgz",
       "integrity": "sha1-Ek/EEUtBKcgQgA7LKshs8lRiy5o=",
       "requires": {
-        "sax": "0.5.8",
-        "xmlbuilder": "9.0.7"
+        "sax": "0.5.x",
+        "xmlbuilder": ">=0.4.2"
       }
     },
     "xmlbuilder": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "dependencies": {
     "discord.js": "11.3.2",
+    "request": "^2.88.0",
+    "request-promise": "^4.2.5",
     "twitch-helix-api": "^1.0.1"
   }
 }

--- a/src-wrs.js
+++ b/src-wrs.js
@@ -1,0 +1,368 @@
+"use strict";
+// typescript source: https://github.com/lepelog/speedruncom-wr-watch/blob/master/src/srcWRs.ts
+const events = require("events");
+const request = require("request-promise");
+const Discord = require("discord.js");
+const gameID = "76rqjqd8"; // botw
+const srcApi = 'https://www.speedrun.com/api/v1/';
+const wrEmitter = new events.EventEmitter();
+const SRC_RUN_LINK_REGEX = /https:\/\/www.speedrun.com\/.+\/run\/([0-9a-z]+)/;
+async function srcWRLoop(lastRunIDs) {
+    lastRunIDs = lastRunIDs || [];
+    const game = await loadGame(gameID);
+    while (true) {
+        try {
+            // grab newly submitted runs
+            const newRuns = await newVerifiedRuns(game, lastRunIDs);
+            for (const run of newRuns) {
+                lastRunIDs.unshift(run.id);
+                // announce new run
+                wrEmitter.emit('newRun', run);
+                // check if it's a new WR or the first run in that category
+                const place = await checkRunPlaceOnLeaderboard(run);
+                if (place === 1) {
+                    wrEmitter.emit('newWR', run);
+                }
+            }
+            // limit to 30 elements
+            lastRunIDs = lastRunIDs.splice(0, 30);
+            // sleep to wait for runs
+            await sleep(30000);
+        }
+        catch (e) {
+            console.error('error during main loop, continuing', e);
+        }
+    }
+}
+async function loadGame(gameID) {
+    const response = await requestWithRetry(`${srcApi}games/${gameID}?embed=categories,variables,levels`, 3);
+    const fullGameVariables = new Map();
+    const levelVariables = new Map();
+    const categories = new Map();
+    const levels = new Map();
+    response.data.categories.data
+        .filter((cat) => cat.type == "per-game")
+        .forEach((cat) => {
+        categories.set(cat.id, { id: cat.id, name: cat.name, variables: new Map() });
+    });
+    const levelCategories = response.data.categories.data
+        .filter((cat) => cat.type == "per-level")
+        .map((cat) => {
+        return { id: cat.id, name: cat.name, variables: new Map() };
+    });
+    response.data.levels.data.map((l) => {
+        levels.set(l.id, {
+            levelId: l.id,
+            levelName: l.name,
+            // copy
+            categories: new Map(levelCategories.map(cat => {
+                return [cat.id, { id: cat.id, name: cat.name, variables: new Map() }];
+            })),
+        });
+    });
+    response.data.variables.data.forEach((variable) => {
+        // only split by subcategories and amiibo
+        if (!variable["is-subcategory"] && variable.name != 'amiibo')
+            return;
+        let v = { name: variable.name, id: variable.id, values: new Map() };
+        Object.entries(variable.values.values).forEach(([id, val]) => {
+            v.values.set(id, val.label);
+        });
+        if (variable.scope.type == "global") {
+            if (variable.category != null) {
+                let cat = categories.get(variable.category);
+                if (cat) {
+                    cat.variables.set(v.id, v);
+                }
+            }
+            else {
+                fullGameVariables.set(v.id, v);
+            }
+        }
+        else if (variable.scope.type == "full-game") {
+            if (variable.category != null) {
+                let cat = categories.get(variable.category);
+                if (cat) {
+                    cat.variables.set(v.id, v);
+                }
+            }
+            else {
+                fullGameVariables.set(v.id, v);
+            }
+        }
+        else if (variable.scope.type == "all-levels") {
+            if (variable.category != null) {
+                levels.forEach(level => {
+                    let cat = level.categories.get(variable.category);
+                    if (cat) {
+                        cat.variables.set(v.id, v);
+                    }
+                });
+            }
+            else {
+                levelVariables.set(v.id, v);
+            }
+        }
+        else if (variable.scope.type == "single-level") {
+            const level = levels.get(variable.scope.level);
+            if (level) {
+                if (variable.category != null) {
+                    let cat = level.categories.get(variable.category);
+                    if (cat) {
+                        cat.variables.set(v.id, v);
+                    }
+                }
+                else {
+                    level.categories.forEach(cat => {
+                        cat.variables.set(v.id, v);
+                    });
+                }
+            }
+        }
+    });
+    return {
+        abbreviation: response.data.abbreviation,
+        name: response.data.names.international,
+        id: gameID,
+        categories,
+        fullGameVariables,
+        levelVariables,
+        levels
+    };
+}
+// no amiibo any% WR: https://www.speedrun.com/api/v1/leaderboards/76rqjqd8/category/vdoq4xvk?top=1&embed=players&var-gnxrr7gn=klr0jj0l
+async function newVerifiedRuns(game, lastRunIDs) {
+    const runData = await requestWithRetry(`https://www.speedrun.com/api/v1/runs?game=${game.id}&status=verified&direction=desc&orderby=verify-date&embed=players&max=30`, 3);
+    const newRuns = [];
+    for (let i = 0; i < runData.data.length; i++) {
+        let curRun = runData.data[i];
+        if (!lastRunIDs.includes(curRun.id)) {
+            newRuns.push(parseRun(curRun, game));
+        }
+        else {
+            break;
+        }
+    }
+    return newRuns;
+}
+function parseRun(srcData, game) {
+    const rawVariables = srcData.values;
+    const gameCategoryVariables = new Map();
+    const parsedRun = {
+        category: '',
+        categoryID: '',
+        game: game.name,
+        gameID: game.id,
+        gameAbbreviation: game.abbreviation,
+        id: srcData.id,
+        playerName: srcData.players.data[0].names.international,
+        playerID: srcData.players.data[0].id,
+        time: srcData.times.primary_t,
+        level: null,
+        levelID: null,
+        variables: []
+    };
+    if (srcData.level) {
+        game.levelVariables.forEach((vari, id) => {
+            gameCategoryVariables.set(id, vari);
+        });
+        const level = game.levels.get(srcData.level);
+        if (!level) {
+            throw new Error(`Level ${srcData.level} doesn't exist for run ${srcData.id}`);
+        }
+        const category = level.categories.get(srcData.category);
+        if (!category) {
+            throw new Error(`Category ${srcData.category} doesn't exist for run ${srcData.id}`);
+        }
+        category.variables.forEach((vari, id) => {
+            gameCategoryVariables.set(id, vari);
+        });
+        parsedRun.level = level.levelName;
+        parsedRun.levelID = level.levelId;
+        parsedRun.category = category.name;
+        parsedRun.categoryID = category.id;
+    }
+    else {
+        game.fullGameVariables.forEach((vari, id) => {
+            gameCategoryVariables.set(id, vari);
+        });
+        const category = game.categories.get(srcData.category);
+        if (!category) {
+            throw new Error(`Category ${srcData.category} doesn't exist for run ${srcData.id}`);
+        }
+        category.variables.forEach((vari, id) => {
+            gameCategoryVariables.set(id, vari);
+        });
+        parsedRun.category = category.name;
+        parsedRun.categoryID = category.id;
+    }
+    Object.entries(rawVariables).forEach(([variableId, valueId]) => {
+        const vari = gameCategoryVariables.get(variableId);
+        if (vari) {
+            const value = vari.values.get(valueId) || '';
+            parsedRun.variables.push({
+                id: vari.id,
+                name: vari.name,
+                valueId: valueId,
+                valueName: value
+            });
+        }
+    });
+    return parsedRun;
+}
+async function checkRunPlaceOnLeaderboard(run) {
+    const varString = run.variables.map(v => `var-${v.id}=${v.valueId}`).join('&');
+    let result;
+    if (run.levelID) {
+        result = await requestWithRetry(`https://www.speedrun.com/api/v1/leaderboards/${run.gameID}/level/${run.levelID}/${run.categoryID}?${varString}`, 3);
+    }
+    else {
+        result = await requestWithRetry(`https://www.speedrun.com/api/v1/leaderboards/${run.gameID}/category/${run.categoryID}?${varString}`, 3);
+    }
+    // try to find the run id
+    const placement = result.data.runs.find((r) => r.run.id == run.id);
+    if (placement) {
+        return placement.place;
+    }
+    else {
+        return null;
+    }
+}
+function formatRun(run) {
+    let category;
+    if (run.level) {
+        category = `${run.level} ${run.category}`;
+    }
+    else {
+        category = run.category;
+    }
+    let subcategories = `${run.variables.map(v => v.valueName).join(', ')}`;
+    return `${category} (${subcategories}) by ${run.playerName} in ${formatTime(run.time)}`;
+}
+async function formatSendRun(channel, info) {
+    return channel.send({
+        embed: {
+            title: `NEW World Record`,
+            url: `https://www.speedrun.com/${info.gameAbbreviation}/run/${info.id}`,
+            color: 0xffcd2e,
+            description: `A new WR has been posted for ${formatCategoryWithVars(info)}`,
+            fields: [{ name: "Runner", value: info.playerName }, { name: "Time", value: formatTime(info.time) }],
+        }
+    });
+}
+async function getAlreadyAnnouncedRunIDs(channel) {
+    let categoryIDs = [];
+    let fetched = await channel.fetchMessages({ limit: 30 });
+    fetched.forEach(message => {
+        if (message.embeds.length == 1) {
+            const link = message.embeds[0].url;
+            if (link) {
+                let match = SRC_RUN_LINK_REGEX.exec(link);
+                if (match && match.length == 2) {
+                    categoryIDs.push(match[1]);
+                }
+            }
+        }
+    });
+    return categoryIDs;
+}
+// helpers
+function formatCategoryWithVars(run) {
+    const varString = run.variables.map(v => v.valueName).join(', ');
+    if (run.levelID != null) {
+        return `${run.level} ${run.category} (${varString})`;
+    }
+    else {
+        return `${run.category} (${varString})`;
+    }
+}
+function formatTime(time) {
+    let secStr;
+    let secs = (time % 60);
+    if (secs < 10) {
+        secStr = '0' + (time % 60).toFixed(3);
+    }
+    else {
+        secStr = (time % 60).toFixed(3);
+    }
+    if (secStr.endsWith('.000')) {
+        secStr = secStr.slice(0, secStr.length - 4);
+        secStr = secStr.slice();
+    }
+    const min = Math.floor((time / 60) % 60);
+    let minStr;
+    if (min == 0) {
+        minStr = '';
+    }
+    else if (min < 10) {
+        minStr = `0${min}m `;
+    }
+    else {
+        minStr = `${min}m `;
+    }
+    const hour = Math.floor(time / 3600);
+    let hStr;
+    if (hour == 0) {
+        hStr = '';
+    }
+    else {
+        hStr = `${hour}h `;
+    }
+    return `${hStr}${minStr}${secStr}s`;
+}
+/**
+ * Oops the site is under a lot of pressure right now
+ */
+async function requestWithRetry(url, retries) {
+    for (let i = 0; i < retries; i++) {
+        try {
+            return await request.get(url, { json: true });
+        }
+        catch (err) {
+            console.error(`Error for url ${url}:`, err);
+        }
+        await sleep(5000);
+    }
+    throw new Error(`too many retries for url ${url}`);
+}
+async function sleep(ms) {
+    return new Promise(resolve => {
+        setTimeout(resolve, ms);
+    });
+}
+/*wrEmitter.on('newRun', (run: Run) => {
+    console.log('New run:',run);
+});*/
+//discordTest();
+// example usage
+async function discordTest() {
+    const client = new Discord.Client();
+    client.login("your token here");
+    client.on('ready', async () => {
+        const channel = client.channels.get("channel id here");
+        if (channel) {
+            const alreadyAnnouncedRunIDs = await getAlreadyAnnouncedRunIDs(channel);
+            console.log(`found ${alreadyAnnouncedRunIDs.length} announced WRs`);
+            srcWRLoop(alreadyAnnouncedRunIDs);
+            wrEmitter.on('newWR', async (run) => {
+                try {
+                    await formatSendRun(channel, run);
+                }
+                catch (e) {
+                    console.log('error formatSendRun', e);
+                }
+            });
+        }
+        else {
+            console.error('channel not found!');
+        }
+    });
+}
+module.exports = {
+    srcWRLoop,
+    wrEmitter,
+    formatCategoryWithVars,
+    formatTime,
+    getAlreadyAnnouncedRunIDs,
+    formatSendRun,
+};


### PR DESCRIPTION
Now the bot can post new WRs for BotW in the channel specified by 'discord-wr-channel-id' in the config. It logs new full game and IL records and has support for subcategories (currently amiibos are treated as a subcategory as well)
This grabs the 30 latest verified runs and then asks SRC about their place on the leaderboard, if it's 1 the run gets posted as a new WR. To make sure no server restarts mess it up it looks in the message history of the WR channel to find already announced records. This will lead to the bot announcing a few records at initial startup though.
![An example how it looks like](https://user-images.githubusercontent.com/25211966/68493558-fb977a80-024c-11ea-9e27-b934074037e8.png)
